### PR TITLE
fail compile if on unsupported platform (windows support)

### DIFF
--- a/src/helpers.zig
+++ b/src/helpers.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const dns = @import("lib.zig");
 
 const CidrRange = @import("cidr.zig").CidrRange;
@@ -263,6 +264,9 @@ pub fn connectToResolver(address: []const u8) !DNSConnection {
 /// "/etc/resolv.conf" file.
 pub fn connectToSystemResolver() !DNSConnection {
     var out_buffer: [256]u8 = undefined;
+
+    if (builtin.os.tag != .linux) @compileError("connectToSystemResolver not supported on this target");
+
     const nameserver_address_string = (try randomNameserver(&out_buffer)).?;
 
     return connectToResolver(nameserver_address_string);


### PR DESCRIPTION
this fails the compile, if the `connectToSystemResolver` function is called, when the target is an unsupported platform.

usually the library would crash on windows, as the hardcoded dependency on `/etc/resolv.conf` is not available, this makes it a compile time failure.

originally I planned to completely support windows, but the winapi doesn't have a standard api for accessing the default dns server as configured at the interface.

it seems the approach would be to iterate over all interfaces listed in the registry under `HKLM:\SYSTEM\ControlSet001\Services\Tcpip\Parameters\Interfaces`, then find the currently active one and then query the `DhcpNameServer` key. this then would either require a dependency on `zigwin32`, or direct calls to the win32 api, as the zig standard library does not expose the required calls.

before I start with this, are you interested in that contribution, and if yes, would you rather see the zigwin32 dependency or direct calls with `extern`