### PR TITLE
windows support

### DIFF
--- a/src/helpers.zig
+++ b/src/helpers.zig
@@ -279,6 +279,7 @@ pub fn connectToResolver(address: []const u8, port: ?u16) !DNSConnection {
 pub fn connectToSystemResolver() !DNSConnection {
     var out_buffer: [256]u8 = undefined;
 
+    if (builtin.is_test and builtin.os.tag != .linux) return error.SkipZigTest;
     if (builtin.os.tag != .linux) @compileError("connectToSystemResolver not supported on this target");
 
     const nameserver_address_string = (try randomNameserver(&out_buffer)).?;


### PR DESCRIPTION
this enables windows support for the library, as discussed in #16 .

things this PR does:
- implement `getAddressList` for windows
    - i am not too happy about the error handling and would be happy about any pointers
- fix `connectToResolver` compile problem under windows
- get the main `zigdig` executable to compile under windows
    - here I am not too happy about depending on one specific DNS server, especially not googles
    - I didn't want to introduce a platform specific cli option
    - I didn't want to enumerate the windows registry to find the configured dns server
    - maybe @lun-4 has an idea here for the UX