### PR TITLE
build: use lib.zig for module root_source_file

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,7 +26,7 @@ pub fn build(b: *Builder) void {
     if (option_libc) exe.linkLibC();
     b.installArtifact(exe_tinyhost);
 
-    _ = b.addModule("zigdig", .{ .root_source_file = b.path("src/main.zig") });
+    _ = b.addModule("zigdig", .{ .root_source_file = b.path("src/lib.zig") });
     const lib_tests = b.addTest(.{
         .root_source_file = b.path("src/test.zig"),
         .target = target,


### PR DESCRIPTION
The public module API is exposed through lib.zig, not main.zig
